### PR TITLE
Fix Arena2v2 frame position.

### DIFF
--- a/ElvUI_Sirus/Modules/Skins/Blizzard/LFD.lua
+++ b/ElvUI_Sirus/Modules/Skins/Blizzard/LFD.lua
@@ -358,7 +358,7 @@ local function LoadSkin()
 	StyleRewardFrame(ConquestFrame.BottomInset.ArenaContainer.Header.RewardFrame)
 
 	StyleButton(ConquestFrame.BottomInset.ArenaContainer.Arena2v2)
-	ConquestFrame.BottomInset.ArenaContainer.Arena2v2:Point("TOP", ConquestFrame.BottomInset.ArenaContainer.Header, "BOTTOM", 0, -6)
+	ConquestFrame.BottomInset.ArenaContainer.Arena2v2:Point("TOP", ConquestFrame.BottomInset.ArenaContainer.Header, "BOTTOM", 0, 10)
 	StyleButton(ConquestFrame.BottomInset.ArenaContainer.Arena3v3)
 	ConquestFrame.BottomInset.ArenaContainer.Arena3v3:Point("TOP", ConquestFrame.BottomInset.ArenaContainer.Arena2v2, "BOTTOM", 0, -(E.Border*2))
 


### PR DESCRIPTION
Фрейм рейтинговых боев немного съехал вниз:
![before](https://user-images.githubusercontent.com/16374845/65806679-65732d80-e193-11e9-9fcf-a0a619f262e9.jpg)

Вот что вышло:
![after](https://user-images.githubusercontent.com/16374845/65806711-89cf0a00-e193-11e9-8aa1-c759363f333c.jpg)
